### PR TITLE
Bump Slevomat coding standards to version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "type": "phpcodesniffer-standard",
     "require": {
-        "slevomat/coding-standard": "^5.0",
+        "slevomat/coding-standard": "^7.0",
         "squizlabs/php_codesniffer": "^3.5",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1"
     }


### PR DESCRIPTION
This adds improved support for PHP 7.4 and 8.